### PR TITLE
Add composer.json file to allow for composer installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+	"name": "seamusleahy/ACF-PHP-Recovery",
+	"desciption": "WordPress plugin to recovery Advanced Custom Fields fieldsets from PHP export",
+	"type": "wordpress-plugin",
+    "homepage": "https://github.com/seamusleahy/ACF-PHP-Recovery",
+    "require": {
+        "php": ">=5.4"
+    }
+}


### PR DESCRIPTION
Hey there! Love your plugin and have used it for a few projects now. Makes recording changes to ACF in git (via PHP files) a viable solution, finally, which has been a godsend for collaboration. 

In my fork of your repo, I added this composer.json file to allow for easy installation with composer; it's made my process quite a bit easier and I thought you might want others to be able to install with composer as well! If you merge this into your repo (and make a Release as 1.0), people can add `"seamusleahy/ACF-PHP-Recovery": "1.*"` to their composer.json files and install your plugin from the command line. 

Food for thought! And thanks again for a great plugin. 